### PR TITLE
[2020-01-04]용석:HttpSecurity의 formLogin() 인증 방식 관련 설정 추가

### DIFF
--- a/src/main/java/io/example/security/config/SecurityConfig.java
+++ b/src/main/java/io/example/security/config/SecurityConfig.java
@@ -1,0 +1,69 @@
+package io.example.security.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Configuration
+@EnableWebSecurity
+@Slf4j
+public class SecurityConfig extends WebSecurityConfigurerAdapter {
+
+    /** 용석 : 2021-01-03
+     * configure(HttpSecurity http) 재 정의를 통해 시스템에 필요한 사용자 정의 인가/인증 정책을 설정
+     * - HttpSecurity : 인가/인증 설정 관련 기능 제공
+     */
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        /* HttpSecurity 재 정의를 통한 인가 정책 설정 */
+        http
+                .authorizeRequests()
+                .anyRequest().authenticated();
+
+        /* HttpSecurity 재 정의를 통한 인증 정책 설정 */
+        http
+                .formLogin()
+//                .loginPage("/custom_login")                 // 로그인 페이지 경로 설정
+                .defaultSuccessUrl("/api/index")            // 로그인 성공 시 화면 이동 경로 설정
+                .failureForwardUrl("/login")                // 로그인 실패 시 화면 이동 경로 설정
+                .usernameParameter("custom_username")       // 로그인 폼 요청 시 기본값으로 설정된 username에 해당하는 파라미터 명 설정
+                .passwordParameter("custom_password")       // 로그인 폼 요청 시 기본값으로 설정된 password에 해당하는 파라미터 명 설정
+                .loginProcessingUrl("/custom_login")        // 로그인 폼 요청 시 기본값으로 설정된 "/login" action URL 설정
+                .successHandler(new AuthenticationSuccessHandler() {    // 로그인 성공 시 Handler를 통한 추가 처리 설정
+                    @Override
+                    public void onAuthenticationSuccess(HttpServletRequest httpServletRequest
+                            , HttpServletResponse httpServletResponse
+                            , Authentication authentication) throws IOException, ServletException {
+                            log.info(authentication.getName());   // 로그인 요청 사용자에 대한 정보 접근 가능
+                            httpServletResponse.sendRedirect("/api/index"); // 로그인 성공 이후 response 객체 접근 가능
+                    }
+                })
+                .failureHandler(new AuthenticationFailureHandler() {    // 로그인 실패 시 Handler를 통한 추가 처리 설정
+                    @Override
+                    public void onAuthenticationFailure(HttpServletRequest httpServletRequest
+                            , HttpServletResponse httpServletResponse
+                            , AuthenticationException e) throws IOException, ServletException {
+                        log.error(e.getMessage()); // 로그인 실패 Exception 객체 접근 가능
+                        httpServletResponse.sendRedirect("/login"); // response를 통해 로그인 실패 후 처리 가능
+                    }
+                })
+
+                /*
+                 * formLogin() 인증 방식에서 설정한 loginPage({loginPage path})의 경로에는
+                 * 인가 정책이 적용되지 않고 누구나 접근 가능하도록 설정
+                 */
+                .permitAll()
+        ;
+    }
+}

--- a/src/main/java/io/example/security/controller/LoginController.java
+++ b/src/main/java/io/example/security/controller/LoginController.java
@@ -1,0 +1,13 @@
+package io.example.security.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class LoginController {
+
+    @GetMapping("/custom_login")
+    public String loginPage(){
+        return "/loginPage";
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
-
+spring.security.user.name=user
+spring.security.user.password=1111

--- a/src/test/java/io/example/security/controller/LoginControllerTest.java
+++ b/src/test/java/io/example/security/controller/LoginControllerTest.java
@@ -1,0 +1,38 @@
+package io.example.security.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.hateoas.MediaTypes;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureMockMvc
+class LoginControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    @DisplayName("Login API : 로그인")
+    public void loginAPI() throws Exception {
+        ResultActions resultActions = this.mockMvc.perform(get("/login")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .accept(MediaTypes.HAL_JSON_VALUE)
+        );
+
+        resultActions.andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("loginPage").exists());
+    }
+}


### PR DESCRIPTION
- HttpSecurity.formLogin().
 - loginPage() : 로그인 페이지 경로 설정
 - defaultSuccessUrl() : 로그인 성공 시 화면 이동 경로 설정
 - failureForwardUrl() : 로그인 실패 시 화면 이동 경로 설정
 - usernameParameter() : 로그인 폼 요청 시 기본값으로 설정된 username에 해당하는 파라미터 명 설정
 - passwordParameter() : 로그인 폼 요청 시 기본값으로 설정된 password에 해당하는 파라미터 명 설정
 - loginProcessingUrl() : 로그인 폼 요청 시 기본값으로 설정된 "/login" action URL 설정
 - successHandler() : 로그인 성공 시 Handler를 통한 추가 처리 설정
 - failureHandler() : 로그인 실패 시 Handler를 통한 추가 처리 설정
 - permitAll() : formLogin() 인증 방식에서 설정한 loginPage({loginPage path})의 경로에는 인가 정책이 적용되지 않고 누구나 접근 가능하도록 설정